### PR TITLE
add prettier-plugin-svelte

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,10 @@ Community maintained:
 - [Sass](https://github.com/ls-age/svelte-preprocess-sass)
 
 
-## Linting
+## Linting and formatting
 
 - [eslint-plugin-svelte3](https://github.com/sveltejs/eslint-plugin-svelte3)
+- [prettier-plugin-svelte](https://github.com/UnwrittenFun/prettier-plugin-svelte)
 
 
 ## Editor extensions


### PR DESCRIPTION
**https://github.com/UnwrittenFun/prettier-plugin-svelte**
Prettier is a popular formatter in the JS ecosystem and is usurping the linter's role in stylistic formatting for a lot of devs, in a harmonizing and pretty way.

<br>

By submitting this pull request, I ~~promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.~~ (**no because link's broken** - [code-of-conduct.md](https://github.com/sveltejs/integrations/blob/master/code-of-conduct.md)?)