### PR TITLE
add hmr bundler plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ Community maintained:
 - [svelte-brunch](https://github.com/kazzkiq/svelte-brunch) - Brunch plugin
 - [sveltejs-brunch](https://github.com/StarpTech/sveltejs-brunch) – Another brunch plugin
 - [rules_svelte](https://github.com/thelgevold/rules_svelte) - Bazel Rules
+- [rollup-plugin-svelte-hot](https://github.com/rixo/rollup-plugin-svelte-hot) - Rollup plugin + HMR
+- [svelte-loader-hot](https://github.com/rixo/svelte-loader-hot) - Webpack loader + HMR
 
 
 ### Preprocessors


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

https://github.com/rixo/rollup-plugin-svelte-hot
https://github.com/rixo/svelte-loader-hot

Those are forks of the official plugins for Rollup and Webpack, with added HMR support.

Svelte HMR is still experimental and, with Rollup, HMR support at all is very much a work in progress. However, I find them to work pretty well for myself already, and I think some other people could be happy with them too.

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.