### PR TITLE
Add Emacs web-mode.el

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,9 @@
   - Vim syntax and indent plugin for .svelte files
   - Supports Less/Sass/Scss, Pug, Coffee, TypeScript.
   - A builtin foldexpr fold method.
-  - emmet-vim HTML/CSS/JavaScript filetype detection.  
+  - emmet-vim HTML/CSS/JavaScript filetype detection.
+- [web-mode.el](https://github.com/fxbois/web-mode)
+  - Emacs major mode including support for Svelte
 - [IntelliJ (WebStorm)](https://plugins.jetbrains.com/plugin/12375-svelte)
 - [Sublime Text: Svelte Syntax Highlighting](https://packagecontrol.io/packages/Svelte)
 - [svelte-vscode](https://marketplace.visualstudio.com/items?itemName=JamesBirtles.svelte-vscode)


### PR DESCRIPTION
Emacs web-mode recently added support for Svelte, so I thought I'd send a quick addition while passing through.

**https://github.com/fxbois/web-mode added support for Svelte in a recent update. This was a really huge thing for me as an Emacs user, so I thought I'd include it along side other editor extensions.**

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.