### PR TITLE
Add coc-svelte to vim plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,8 @@
   - Supports Less/Sass/Scss, Pug, Coffee, TypeScript.
   - A builtin foldexpr fold method.
   - emmet-vim HTML/CSS/JavaScript filetype detection.
+- [coc-svelte](https://github.com/coc-extensions/coc-svelte)
+  - All of the above, also utilises the svelte language server
 - [web-mode.el](https://github.com/fxbois/web-mode)
   - Emacs major mode including support for Svelte
 - [IntelliJ (WebStorm)](https://plugins.jetbrains.com/plugin/12375-svelte)


### PR DESCRIPTION
https://github.com/coc-extensions/coc-svelte

This plugin uses the svelte language server from upstream, so supports most of the same features as the VSCode plugin.

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.