### PR TITLE
Add Svelte with TailwindCSS, PostCSS and i18n template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@
   - Starter template and tutorial for adding ESLint, Jest and Tailwind CSS to the official TypeScript template.
 - [svelte-ts-eslint-prettier-template](https://github.com/NicoCevallos/svelte-template)
   - Starter template with TS activated, and ESLint and Prettier working together.
+ - [svelte-tailwind-i18n-template](https://github.com/Los-Crackitos/svelte-tailwind-i18n-template)
+  - Starter with Tailwind CSS, PostCSS and i18n internationalization preconfigured.
 
 ### Sapper templates (boilerplates)
 


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

[Los-Crackitos/svelte-tailwind-i18n-template](https://github.com/Los-Crackitos/svelte-tailwind-i18n-template)

**[Explain what this item is about and why it should be included here.]**

Preconfigured Svelte 3 template with Tailwind CSS, PostCSS and i18n internationalization.

Can be useful when creating a new project with this technologies or to be used as a tutorial.

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.