### PR TITLE
Add esbuild-svelte

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,8 @@
   - HMR
 - [svite](https://github.com/dominikg/svite)
   - Svelte + Vite = Sweet! 
+- [esbuild-svelte](https://github.com/EMH333/esbuild-svelte)
+  - esbuild plugin
 
 ### Preprocessors
 


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

**https://github.com/EMH333/esbuild-svelte**
This plugin allows Svelte files to be compiled and fed into the wonderfully fast [esbuild](https://github.com/evanw/esbuild) bundler.

Pretty straightforward but let me know if you have any questions!

<br>

- [x] By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.