### PR TITLE
Add svelte-preprocess-html-asset

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@
 - [modular-css](https://github.com/tivac/modular-css/tree/master/packages/svelte)
 - [PostCSS](https://github.com/TehShrike/svelte-preprocess-postcss)
 - [Sass](https://github.com/ls-age/svelte-preprocess-sass)
+- [svelte-preprocess-html-asset](https://github.com/jiangfengming/svelte-preprocess-html-asset)
 
 ## Linting and formatting
 


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

**https://github.com/jiangfengming/svelte-preprocess-html-asset**
**Transform HTML asset's relative path to URL object. For example, `<img src="foo.jpg">` to `<img src={new URL('foo.jpg', import.meta.url)}>`. So the assets can be bundled by webpack's [URL assets](https://webpack.js.org/guides/asset-modules/#url-assets) feature.**

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.