### PR TITLE
Add svelte-preprocess-css-hash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@
 - [PostCSS](https://github.com/TehShrike/svelte-preprocess-postcss)
 - [Sass](https://github.com/ls-age/svelte-preprocess-sass)
 - [svelte-preprocess-css-hash](https://github.com/jiangfengming/svelte-preprocess-css-hash)
-  - Passing hashed css class name to child component. It is used to avoid class name conflicts.
+  - Provides a mechanism to suffix css class names with a hash to avoid conflicts.
 
 ## Linting and formatting
 

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,8 @@
 - [modular-css](https://github.com/tivac/modular-css/tree/master/packages/svelte)
 - [PostCSS](https://github.com/TehShrike/svelte-preprocess-postcss)
 - [Sass](https://github.com/ls-age/svelte-preprocess-sass)
+- [svelte-preprocess-css-hash](https://github.com/jiangfengming/svelte-preprocess-css-hash)
+  - Passing hashed css class name to child component. It is used to avoid class name conflicts.
 
 ## Linting and formatting
 


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

**https://github.com/jiangfengming/svelte-preprocess-css-hash**
**Passing hashed css class name to child component. It is used to avoid class name conflicts.**

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.