### PR TITLE
add svelte-vite-ssr template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,8 @@
   - Starter with Tailwind CSS, PostCSS and i18n internationalization preconfigured.
 - [svelte-flask](https://github.com/SyntaxRules/svelte-flask)
   - A template for building with svelte, and using the flask webserver and routes.
+- [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr)
+  - A Svelte project template with a powerful router, SSR (Server-Side Rendering), CSR (Client-Side Rendering), HMR (Hot Module Replacement), `<link rel="preload">` directives, and other nice features.
 
 ### Sapper templates (boilerplates)
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@
 - [svelte-flask](https://github.com/SyntaxRules/svelte-flask)
   - A template for building with svelte, and using the flask webserver and routes.
 - [svelte-vite-ssr](https://github.com/jiangfengming/svelte-vite-ssr)
-  - A Svelte project template with a powerful router, SSR (Server-Side Rendering), CSR (Client-Side Rendering), HMR (Hot Module Replacement), `<link rel="preload">` directives, and other nice features.
+  - A project template demonstrating usage of the [svelte-pilot](https://github.com/jiangfengming/svelte-pilot) router with Vite. svelte-pilot uses a config file based approach (like vue-router)
 
 ### Sapper templates (boilerplates)
 


### PR DESCRIPTION
<!-- Please fill in the **bold** fields -->

https://github.com/jiangfengming/svelte-vite-ssr
A Svelte project template with a powerful router, SSR (Server-Side Rendering), CSR (Client-Side Rendering), HMR (Hot Module Replacement), `<link rel="preload">` directives, and other nice features.

<br>

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.